### PR TITLE
Specify CCCL version: Latest CCCL does not support CUDA 11.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ find_package(pybind11 REQUIRED)
 CPMAddPackage(
     NAME CCCL
     GITHUB_REPOSITORY nvidia/cccl
-    GIT_TAG main
+    GIT_TAG v2.8.3
 )
 target_link_libraries(RAMA INTERFACE CCCL::CCCL)
 


### PR DESCRIPTION
At the time of writing (2025 May), the latest CCCL version 3.0 does not support CUDA 11.x any more (CUDA 12+ is required).
Therefore, we need to specify the version of CCCL in CMakeLists to an older version to enforce compatibility.
I used the last major version v2.8.3, but I think older ones should work too.